### PR TITLE
Update devcontainer.json to be compliant with the spec

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,3 +1,14 @@
 {
+    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-18",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "mads-hartmann.bash-ide-vscode"
+            ]
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:1": {}
+    },
     "postCreateCommand": "npm install -g @devcontainers/cli"
 }


### PR DESCRIPTION
The current devcontainer.json is not spec compliant since image/Dockerfile/dockerComposeFile are required.

While this may be optional for Codespaces, these repositories are about the overall spec, so we should be sure to stay compliant.